### PR TITLE
Wa waypoint updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 devel
 
 profile.tmp
+
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy==1.13.1
 Pillow==2.2.1
 scipy==0.19.1
 keras==2.0.8
-tensorflow==1.3.0
+tensorflow-gpu==1.3.0
 h5py==2.6.0

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -6,6 +6,7 @@ from styx_msgs.msg import Lane, Waypoint
 
 import math
 import numpy as np
+from scipy.spatial import KDTree
 
 '''
 This node will publish waypoints from the car's current position to some `x` distance ahead.
@@ -37,34 +38,211 @@ class WaypointUpdater(object):
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
-        # TODO: Add other member variables you need below
+        # contains a list of (x,y) tuples for all waypoints
+        self.waypoints_2d = None
+        # KD tree of the x,y waypoints to increase lookup time
+        self.waypoint_tree = None
+        # stores the raw pose message        
+        self.pose_msg = None
 
-        self.base_waypoints = None
-        self.closest_waypoint_id = 0
+        # stores the raw waypoint message of type styx_msgs/Lane
+        self.base_waypoints_msg = None
+        
+        self.publisher_loop(50)
 
+    def publisher_loop(self, frequency):
+        """
+        Task: This method is called from the constructor and is responsible for calling the
+              publishers and their helpers repeatedly.
+        arguments:
+        -frequency: int, the frequency with which to call the publishers
 
-        rospy.spin()
+        returns: Nothing
+        
+        """
+        rate = rospy.Rate(frequency)
+
+        while not rospy.is_shutdown():
+            if self.pose_msg and self.base_waypoints_msg:
+                closest_waypoint_idx = self.get_nearest_waypoint_idx()
+                self.publish_waypoints(closest_waypoint_idx)
+            rate.sleep()
 
     def pose_cb(self, msg):
+        """
+        
+        Task: Processes the messages which contain the current 
+              position of the vehicle in map coordinates
+        arguments:
+        - msg: message type geometry_msgs/PoseStamped
+
+        returns: Nothing
+
+        ROS integration
+        ===        
+        Type: Callback
+        Topic: /current_pose
+        msg_type: geometry_msgs/PoseStamped
+
+        std_msgs/Header header
+          uint32 seq
+          time stamp
+          string frame_id
+        geometry_msgs/Pose pose
+          geometry_msgs/Point position
+            float64 x
+            float64 y
+            float64 z
+          geometry_msgs/Quaternion orientation
+            float64 x
+            float64 y
+            float64 z
+            float64 w        
+        """
+        self.pose_msg = msg
         # check if base waypoints have been loaded
-        if not self.base_waypoints:
+        if not self.base_waypoints_msg:
             return
 
-        # TODO: Find the index of the closest waypoint in self.base_waypoints
-        # Finding the closest waypoint is not trivial because there is an edge case where the car is about to pass
-        # the closest waypoint detected using euclidean distance only.
-        # Therefore the waypoints orientation and the cars current orientation has to be taken in account.
-        # Join the discussion on the forum to see how the problem can solved.
-        # Find the forum thread here: https://discussions.udacity.com/t/how-can-we-tell-if-the-car-have-past-the-nearest-waypoint-or-not/381909
-
-
-        # TODO: Create a list of the upcoming waypoints
-
-        # TODO: Broadcast upcoming waypoints to /final_waypoints
 
 
     def waypoints_cb(self, waypoints):
-        self.base_waypoints = waypoints.waypoints
+        """
+        Task: Processes the waypoints message which contains all of the track's waypoints in map coordinates. 
+              Needs only to run once.
+        arguments:
+        - waypoints: message type styx_msgs/Lane
+        returns: Nothing
+        
+        ROS integration:
+        ===
+        Type: Callback
+        Topic: /base_waypoints
+        msg_type: styx_msgs/Lane
+
+        std_msgs/Header header
+          uint32 seq
+          time stamp
+          string frame_id
+        styx_msgs/Waypoint[] waypoints
+          geometry_msgs/PoseStamped pose
+            std_msgs/Header header
+              uint32 seq
+              time stamp
+              string frame_id
+            geometry_msgs/Pose pose
+              geometry_msgs/Point position
+                float64 x
+                float64 y
+                float64 z
+              geometry_msgs/Quaternion orientation
+                float64 x
+                float64 y
+                float64 z
+                float64 w
+          geometry_msgs/TwistStamped twist
+            std_msgs/Header header
+              uint32 seq
+              time stamp
+              string frame_id
+            geometry_msgs/Twist twist
+              geometry_msgs/Vector3 linear
+                float64 x
+                float64 y
+                float64 z
+              geometry_msgs/Vector3 angular
+                float64 x
+                float64 y
+                float64 z     
+        
+        """
+        self.base_waypoints_msg = waypoints
+        if not self.waypoints_2d:
+            self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in waypoints.waypoints]
+            self.waypoint_tree = KDTree(self.waypoints_2d)
+
+    def publish_waypoints(self, closest_idx):
+        """        
+        Task: Invokes the waypoint publisher and publishes the nearest waypoints to the
+              /final_waypoints topic.
+        arguments:
+        - closest_idx: int, the idx of the nearest waypoints in front of the car.
+
+        ROS integration:
+        ===
+        Type: Publisher
+        Topic: /final_waypoints
+        msg_type: styx_msgs/Lane
+
+        std_msgs/Header header
+          uint32 seq
+          time stamp
+          string frame_id
+        styx_msgs/Waypoint[] waypoints
+          geometry_msgs/PoseStamped pose
+            std_msgs/Header header
+              uint32 seq
+              time stamp
+              string frame_id
+            geometry_msgs/Pose pose
+              geometry_msgs/Point position
+                float64 x
+                float64 y
+                float64 z
+              geometry_msgs/Quaternion orientation
+                float64 x
+                float64 y
+                float64 z
+                float64 w
+          geometry_msgs/TwistStamped twist
+            std_msgs/Header header
+              uint32 seq
+              time stamp
+              string frame_id
+            geometry_msgs/Twist twist
+              geometry_msgs/Vector3 linear
+                float64 x
+                float64 y
+                float64 z
+              geometry_msgs/Vector3 angular
+                float64 x
+                float64 y
+                float64 z
+        
+        """
+        lane = Lane()
+        lane.waypoints = self.base_waypoints_msg[closest_idx:closest_idx + LOOKAHEAD_WPS]
+        self.final_waypoints_pub.publish(lane)
+
+    def get_nearest_waypoint_idx(self):
+        """
+        Task: Finds the nearest waypoint according to the car's current position 
+              and returns the index of that waypoint
+        returns: int, index of nearest waypoint in self.waypoints_2d
+        """
+        x = self.pose_msg.pose.position.x
+        y = self.pose_msg.pose.position.y
+        # lookup the KDtree to find the nearest point and return its index
+        closest_idx = self.waypoint_tree.query([x, y], 1)[1]
+
+        closest_coord = np.array(self.waypoints_2d[closest_idx])
+        prev_coord = np.array(self.waypoints_2d[closest_idx - 1])
+        current_pos = np.array([x, y])
+
+        wp_vec = closest_coord - prev_coord
+        car_vec = closest_coord - current_pos
+
+        # calculate dot product between the two vectors 
+        # to determine if  closest point is ahead of car
+        # -> same heading if dot product is > 0
+        dot_product = np.dot(wp_vec, car_vec)
+
+        # if the closest point is not ahead of the vehicle, choose the next point
+        if dot_product < 0:
+            closest_idx = (closest_idx + 1) % len(self.waypoints_2d)
+        
+        return closest_idx
+
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -20,7 +20,6 @@ Please note that our simulator also provides the exact location of traffic light
 current status in `/vehicle/traffic_lights` message. You can use this message to build this node
 as well as to verify your TL classifier.
 
-TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
@@ -37,7 +36,7 @@ class WaypointUpdater(object):
 
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
-
+        
         # contains a list of (x,y) tuples for all waypoints
         self.waypoints_2d = None
         # KD tree of the x,y waypoints to increase lookup time
@@ -106,10 +105,10 @@ class WaypointUpdater(object):
 
 
 
-    def waypoints_cb(self, waypoints):
+    def waypoints_cb(self, waypoint_msg):
         """
         Task: Processes the waypoints message which contains all of the track's waypoints in map coordinates. 
-              Needs only to run once.
+              Needs only to run once, because the waypoints are sent only once at the beginning.
         arguments:
         - waypoints: message type styx_msgs/Lane
         returns: Nothing
@@ -156,9 +155,9 @@ class WaypointUpdater(object):
                 float64 z     
         
         """
-        self.base_waypoints_msg = waypoints
+        self.base_waypoints_msg = waypoint_msg
         if not self.waypoints_2d:
-            self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in waypoints.waypoints]
+            self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in waypoint_msg.waypoints]
             self.waypoint_tree = KDTree(self.waypoints_2d)
 
     def publish_waypoints(self, closest_idx):
@@ -211,7 +210,7 @@ class WaypointUpdater(object):
         
         """
         lane = Lane()
-        lane.waypoints = self.base_waypoints_msg[closest_idx:closest_idx + LOOKAHEAD_WPS]
+        lane.waypoints = self.base_waypoints_msg.waypoints[closest_idx:closest_idx + LOOKAHEAD_WPS]
         self.final_waypoints_pub.publish(lane)
 
     def get_nearest_waypoint_idx(self):


### PR DESCRIPTION
I've implemented the first step of the waypoint updater, documented and tested it.
If you run `roslaunch launch/styx.launch` now and then fire up the simulator, the nearest waypoints are loaded and displayed. You can drive the car manually and see that the waypoints are updated. But you have to start ROS first, otherwise it will throw an error because the waypoint message is sent only once.